### PR TITLE
Enlarging the "filter values" input box

### DIFF
--- a/moneylog.html
+++ b/moneylog.html
@@ -165,7 +165,7 @@ License/Licença:
 							<select
 								id="opt-value-filter-combo" size="1">
 							</select><input
-								id="opt-value-filter-number" size="3" type="text">
+								id="opt-value-filter-number" size="6" type="text">
 						</div>
 					</div>
 


### PR DESCRIPTION
A size of 3 is too small. It barely fits `-500`, and certainly doesn't fit numbers around thousands. Increasing the size will make it more useful.