### PR TITLE
Using oninput instead of onkeyup

### DIFF
--- a/moneylog.js
+++ b/moneylog.js
@@ -3702,9 +3702,9 @@ function initUI() {
 	document.getElementById('y'                      ).onclick  = changeReport;
 	document.getElementById('opt-value-filter-check' ).onclick  = toggleValueFilter;
 	document.getElementById('opt-value-filter-combo' ).onchange = valueFilterChanged;
-	document.getElementById('opt-value-filter-number').onkeyup  = showReport;
+	document.getElementById('opt-value-filter-number').oninput  = showReport;
 	document.getElementById('opt-monthly-check'      ).onclick  = toggleMonthly;
-	document.getElementById('filter'                 ).onkeyup  = showReport;
+	document.getElementById('filter'                 ).oninput  = showReport;
 	document.getElementById('opt-regex-check'        ).onclick  = showReport;
 	document.getElementById('opt-negate-check'       ).onclick  = showReport;
 	document.getElementById('storage-driver'         ).onchange = ml.storage.driversComboChanged;


### PR DESCRIPTION
The best event for detecting input changes is `input`. It triggers when the field changes by using the mouse (e.g. middle-clicking to paste, or through the context menu), and it doesn't trigger if key presses don't change the string.

There are other event handlers here (onclick?, onchange?) that might be worth revisiting and changing to a better event, but that's not going to happen in this commit (or ever).